### PR TITLE
Fixed dependecy

### DIFF
--- a/include/template2.inc.php
+++ b/include/template2.inc.php
@@ -1002,7 +1002,8 @@ Class Cache{
 	var $caching,
 		$cache_dir,
 		$cache_file,
-		$cache_file_lifetime;
+		$cache_file_lifetime,
+		$template_file_name;
 	
    function __construct($template_file){
 		$this->cache_dir = $this->setDefaultCacheDir();
@@ -1138,7 +1139,8 @@ Class ForeachCode {
 	var $foreachCodeArray,
 		$placeholderArray,
 		$foreachHierarchyArray,
-		$deep;
+		$deep,
+		$foreachCounter;
 		
 	function __construct(){
 		$this->deep=0;


### PR DESCRIPTION
Fixed a dependecy with deprecated sintax in PHP 8+. In fact, it is no longer possible to declare instance variables in the constructor if they havn't been declared first in the class. Error on line 1011 and 1145 with the variables `template_file_name` and `foreachCounter`. 